### PR TITLE
fix(widget_bug): Verify that @nikitadmitrieff/feedback-chat/styles.css is pro

### DIFF
--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -15,10 +15,7 @@
       "import": "./dist/server/index.js",
       "default": "./dist/server/index.js"
     },
-    "./styles.css": {
-      "import": "./dist/styles.css",
-      "default": "./dist/styles.css"
-    }
+    "./styles.css": "./dist/styles.css"
   },
   "bin": {
     "feedback-chat": "./dist/cli/init.js",


### PR DESCRIPTION
## Self-Improvement Fix

**Category:** `widget_bug`
**Source run:** aabbccdd-0000-4000-8000-000000000002

### Failure Analysis
The agent attempted to import styles from @nikitadmitrieff/feedback-chat/styles.css, but this export path does not exist in the widget's source code. The build consistently failed across all three retry attempts with the same module resolution error, indicating the widget's export configuration (package.json exports field, file structure, or CSS bundling) is broken or incomplete. This is not a documentation gap because the agent knew to import styles; rather, the widget itself is missing or misconfiguring the styles export that consumers expect to use.

### Suggested Fix
Verify that @nikitadmitrieff/feedback-chat/styles.css is properly exported in package.json and that the CSS file exists at the correct path in packages/widget/, or update the export path to match the actual file location.

---
*Auto-generated by the self-improvement pipeline.*